### PR TITLE
Fixed OP-Checkout logo image src

### DIFF
--- a/app/code/Op/Checkout/view/frontend/web/template/payment/checkout-bypass.html
+++ b/app/code/Op/Checkout/view/frontend/web/template/payment/checkout-bypass.html
@@ -7,8 +7,7 @@
         <label data-bind="attr: {'for': getCode()}" class="label">
             <div class="checkout-logo">
                 <div class="checkout-logo-container">
-                    <img src="https://checkout.fi/wp-content/uploads/checkout-logo-pysty-RGB.png">
-                    <!-- TODO: uncomment when live <img src="https://cdn2.hubspot.net/hubfs/2610868/ext-media/op-psp-master-logo.svg" alt="OP Checkout">-->
+                    <img src="https://cdn2.hubspot.net/hubfs/2610868/ext-media/op-psp-master-logo.svg" alt="OP Checkout">
                 </div>
             </div>
         </label>


### PR DESCRIPTION
As https://checkout.fi/wp-content/uploads/checkout-logo-pysty-RGB.png does not exist anymore switched logo image src to https://cdn2.hubspot.net/hubfs/2610868/ext-media/op-psp-master-logo.svg.

Related issue : https://github.com/CheckoutFinland/plugin-magento2/issues/1